### PR TITLE
Updates component to vaadin 24.0

### DIFF
--- a/autocomplete-demo/pom.xml
+++ b/autocomplete-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>autocomplete-demo</artifactId>
     <packaging>war</packaging>
-    <version>2.3.2</version>
+    <version>3.0.0</version>
     <name>Autocomplete Demo</name>
     <inceptionYear>2018</inceptionYear>
 
@@ -17,10 +17,9 @@
 
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <vaadin.version>23.2.6</vaadin.version>
-        <flow.version>2.6.3</flow.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <vaadin.version>24.0.5</vaadin.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -77,7 +76,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.46.v20220331</version>
+                <version>11.0.15</version>
                 <configuration>
                     <scanIntervalSeconds>1</scanIntervalSeconds>
                 </configuration>
@@ -89,6 +88,18 @@
                 <configuration>
                     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-maven-plugin</artifactId>
+                <version>${vaadin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                          <goal>prepare-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/autocomplete/pom.xml
+++ b/autocomplete/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>autocomplete</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.2</version>
+    <version>3.0.0</version>
 
     <name>Autocomplete</name>
 
@@ -18,10 +18,9 @@
 
 
     <properties>
-        <jetty.plugin.version>9.4.46.v20220331</jetty.plugin.version>
-        <vaadin.version>23.2.6</vaadin.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <vaadin.version>24.0.5</vaadin.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>autocomplete-root</artifactId>
 	<packaging>pom</packaging>
-	<version>23.0.0</version>
+	<version>3.0.0</version>
 	<name>Autocomplete Root</name>
 	<inceptionYear>2018</inceptionYear>
 	<organization>
@@ -15,9 +15,9 @@
 	</organization>
 
 	<properties>
-		<vaadin.version>23.2.6</vaadin.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<vaadin.version>24.0.5</vaadin.version>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>


### PR DESCRIPTION
Notes:

- it depends on https://github.com/vaadin-component-factory/vcf-autocomplete/pull/9
- I haven't pushed the generated files
- to be able to run the demo I had to add '--add-opens=java.base/java.lang=ALL-UNNAMED' to the jvm args. I don't think if it should be addressed in this PR