### PR TITLE
prevent JavaScript injection with setValue()

### DIFF
--- a/autocomplete/src/main/java/com/vaadin/componentfactory/Autocomplete.java
+++ b/autocomplete/src/main/java/com/vaadin/componentfactory/Autocomplete.java
@@ -224,7 +224,7 @@ public class Autocomplete extends LitTemplate implements HasTheme, HasSize,
     }
 
     public void setValue(String value) {
-        getElement().executeJs("this._setValue(\"" + value + "\");");
+        getElement().callJsFunction("_setValue", value);
     }
 
     @Synchronize(property = VALUE_PROP, value = "value-changed")


### PR DESCRIPTION
It is a bad idea to concatenate a JavaScript expression with a value that may be from a user input. The call of
autocommit.setValue("xy\");alert(\"Hello World!"); leads to the alert window shown in the browser.